### PR TITLE
RDKB-63408: RFC Unable To Handle Larger Enablement Config

### DIFF
--- a/source/secure_wrapper.c
+++ b/source/secure_wrapper.c
@@ -43,7 +43,7 @@
 #  define LOG_LIB 0
 #endif
 
-#define MAX_ARG_LEN 1024
+#define MAX_ARG_LEN 2048
 #define MAX_NUM_ARGS 512
 #define MAX_NUM_CMDS 32
 


### PR DESCRIPTION
Added the size increase to allow large size arguments for v secure system